### PR TITLE
Re-render map on click, brush now can hold both terrain and icon changes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@types/node": "^16.18.68",
         "@types/react": "^18.2.45",
         "@types/react-dom": "^18.2.18",
+        "classnames": "^2.5.1",
         "lodash": "^4.17.21",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -5796,6 +5797,11 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.2.3.tgz",
       "integrity": "sha512-0TNiGstbQmCFwt4akjjBg5pLRTSyj/PkWQ1ZoO2zntmg9yLqSRxwEa4iCfQLGjqhiqBfOJa7W/E8wfGrTDmlZQ=="
+    },
+    "node_modules/classnames": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
+      "integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow=="
     },
     "node_modules/clean-css": {
       "version": "5.3.3",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "@types/node": "^16.18.68",
     "@types/react": "^18.2.45",
     "@types/react-dom": "^18.2.18",
+    "classnames": "^2.5.1",
     "lodash": "^4.17.21",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,8 +1,6 @@
 import './App.css';
 
-import Bonus from './components/Bonus';
-import { Terrain, TerrainMap } from './Model/terrain';
-import React, { useState } from 'react';
+import { useState } from 'react';
 import './App.css';
 import HexagonGrid from './components/HexagonGrid';
 import BrushBox from './components/Brushbox';
@@ -13,22 +11,17 @@ import { HexData } from './Model/hex';
 function App() {
   const [brushSelection, setBrushSelection] = useState({} as BrushSelection);
   const { terrain, icon } = brushSelection;
+  const [hexagons, setHexagons] = useState([] as HexData[])
 
-  const hexagons: HexData[] = [
-    {
-      index: 3,
-      terrain: Terrain.ROCK
-    }
-  ];
 
   return (
     <div className="App">
       "Icon Id: {icon}"
       "Terrain Id: {terrain}"
       <BrushSelectionContext.Provider value={brushSelection}>
-        <HexagonGrid hexagons={hexagons} />
-        <BrushBox setBrushSelection={setBrushSelection} />
-        <BrushBoxTextures setBrushSelection={setBrushSelection} />
+        <HexagonGrid hexagons={hexagons} setHexagons={setHexagons}/>
+        <BrushBox brushSelection={brushSelection} setBrushSelection={setBrushSelection} />
+        <BrushBoxTextures brushSelection={brushSelection} setBrushSelection={setBrushSelection} />
       </BrushSelectionContext.Provider>
     </div>
   );

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,8 +20,8 @@ function App() {
       "Terrain Id: {terrain}"
       <BrushSelectionContext.Provider value={brushSelection}>
         <HexagonGrid hexagons={hexagons} setHexagons={setHexagons}/>
-        <BrushBox brushSelection={brushSelection} setBrushSelection={setBrushSelection} />
-        <BrushBoxTextures brushSelection={brushSelection} setBrushSelection={setBrushSelection} />
+        <BrushBox setBrushSelection={setBrushSelection} />
+        <BrushBoxTextures setBrushSelection={setBrushSelection} />
       </BrushSelectionContext.Provider>
     </div>
   );

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -21,8 +21,8 @@ function App() {
       "Brush:  {brushSelection.icon} {brushSelection.terrain}""
       <BrushSelectionContext.Provider value={brushSelection}>
         <HexagonGrid hexagons={hexagons} setHexagons={setHexagons}/>
-        <BrushBox setBrushSelection={setBrushSelection} />
-        <BrushBoxTextures setBrushSelection={setBrushSelection} />
+        <BrushBox setBrushSelection={setBrushSelection} brushSelection={brushSelection}/>
+        <BrushBoxTextures setBrushSelection={setBrushSelection} brushSelection={brushSelection}/>
       </BrushSelectionContext.Provider>
     </div>
   );

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,13 +11,14 @@ import { HexData } from './Model/hex';
 function App() {
   const [brushSelection, setBrushSelection] = useState({} as BrushSelection);
   const { terrain, icon } = brushSelection;
-  const [hexagons, setHexagons] = useState([] as HexData[])
+  const [hexagons, setHexagons] = useState<HexData[]>([])
 
 
   return (
     <div className="App">
       "Icon Id: {icon}"
       "Terrain Id: {terrain}"
+      "Brush:  {brushSelection.icon} {brushSelection.terrain}""
       <BrushSelectionContext.Provider value={brushSelection}>
         <HexagonGrid hexagons={hexagons} setHexagons={setHexagons}/>
         <BrushBox setBrushSelection={setBrushSelection} />

--- a/src/Model/hex.ts
+++ b/src/Model/hex.ts
@@ -9,7 +9,7 @@ export interface BonusData {
 
 export interface HexData {
   index: number;
-  terrain: Terrain;
+  terrain?: Terrain;
   upgradeRequired?: boolean;
   bonus?: BonusData;
 }
@@ -27,14 +27,14 @@ export function stringify(hex: HexData) {
   }
   let array: Uint8Array = hex.bonus ? new Uint8Array([
     hex.index,
-    hex.terrain,
+    hex.terrain || Terrain.NORMAL,
     hex.upgradeRequired ? 1 : 0,
     hex.bonus.icon,
     hex.bonus.value || 0,
     hex.bonus.hideContainer ? 1 : 0
   ]) : new Uint8Array([
     hex.index,
-    hex.terrain,
+    hex.terrain || Terrain.NORMAL,
     hex.upgradeRequired ? 1 : 0
   ]);
 

--- a/src/Model/icon.ts
+++ b/src/Model/icon.ts
@@ -22,6 +22,16 @@ export enum Icon {
   Tower,
 }
 
+
+export const VALUE_ICONS = [
+  Icon.Money,
+  Icon.Reputation,
+  Icon.Hunter,
+  Icon.Sunbathing,
+  Icon.Perception,
+  Icon.Pouch,
+];
+
 export class IconConfig {
   constructor(
     readonly icon: Icon,

--- a/src/Model/icon.ts
+++ b/src/Model/icon.ts
@@ -31,6 +31,8 @@ export class IconConfig {
   ) { }
 }
 
+export const BonusConfig = new IconConfig(Icon.Bonus, 50.026, 40.739, 1750);
+
 export const IconMap: Map<Icon, IconConfig> =
   new Map([
     [Icon.Reputation, 7.150, 40.784, 1735.6],
@@ -43,6 +45,5 @@ export const IconMap: Map<Icon, IconConfig> =
     [Icon.Clever, 39.490, 40.739, 2385.3],
     [Icon.Marketing, 97.179, 40.694, 1765.5],
     [Icon.Tower, 78.898, 1.1312, 2946.8],
-    [Icon.Bonus, 50.026, 40.739, 1750],
-  ].map(([icon, x, y, size]) => [icon, new IconConfig(icon, x, y, size)]));
+  ].map(([icon, x, y, size]) => [icon, new IconConfig(icon, x, y, size)]));    
 

--- a/src/components/Bonus.tsx
+++ b/src/components/Bonus.tsx
@@ -1,16 +1,8 @@
 import './Bonus.css';
 
-import { IconMap, Icon } from "../Model/icon";
+import { IconMap, Icon, VALUE_ICONS } from "../Model/icon";
 import { BonusData } from '../Model/hex';
 
-const VALUE_ICONS = [
-  Icon.Money,
-  Icon.Reputation,
-  Icon.Hunter,
-  Icon.Sunbathing,
-  Icon.Perception,
-  Icon.Pouch,
-];
 
 function Bonus(
   props: {

--- a/src/components/Bonus.tsx
+++ b/src/components/Bonus.tsx
@@ -1,7 +1,16 @@
 import './Bonus.css';
 
-import { IconMap } from "../Model/icon";
+import { IconMap, Icon } from "../Model/icon";
 import { BonusData } from '../Model/hex';
+
+const VALUE_ICONS = [
+  Icon.Money,
+  Icon.Reputation,
+  Icon.Hunter,
+  Icon.Sunbathing,
+  Icon.Perception,
+  Icon.Pouch,
+];
 
 function Bonus(
   props: {
@@ -9,15 +18,23 @@ function Bonus(
   }
 ) {
   const { icon, value, hideContainer } = props.bonusData;
+
+
+  const hasValue = VALUE_ICONS.includes(icon);
   const config = IconMap.get(icon)!;
   let iconStyle = {
     backgroundPosition: `${config.x}% ${config.y}%`,
     backgroundSize: `${config.size}%`,
   }
-  return <div className="icon-container">
+  const innerIcon =
     <div style={iconStyle} className="icon">
-      <span className="icon-value">{value}</span>
-    </div>
+      {hasValue ? (<span className="icon-value">{value}</span>) : <></>}
+    </div>;
+  if (hideContainer) {
+    return innerIcon
+  }
+  return <div className="icon-container">
+    {innerIcon}
   </div>;
 }
 

--- a/src/components/Brushbox-textures.css
+++ b/src/components/Brushbox-textures.css
@@ -13,7 +13,7 @@
     background-color:aqua;
   }
 
-  .mountain {
+  .rock {
     background-color:gray;
     color: white;
   }

--- a/src/components/Brushbox-textures.tsx
+++ b/src/components/Brushbox-textures.tsx
@@ -4,41 +4,44 @@ import { Terrain } from "../Model/terrain";
 import { BrushSelection } from "../context";
 
 interface BrushBoxProps {
-    setBrushSelection: (selection: BrushSelection) => void;
+  setBrushSelection: (selection: BrushSelection) => void;
+  brushSelection: BrushSelection;
 }
 
-
 const BrushBoxTextures = (props: BrushBoxProps) => {
-    const {setBrushSelection} = props
-    const [clicked, setClicked] = useState(-1)
-    const [key, setKey] = useState(0)
+  const { setBrushSelection, brushSelection } = props
 
-    const onClickIcon = (terrain: Terrain) => {
-        setBrushSelection({ terrain });
-        setClicked(terrain)
-    }
+  const onClickIcon = (terrain: Terrain) => {
+    setBrushSelection({ terrain });
+  }
 
-    const selected = clicked == key ? "selected" : "";
-
-    return (
-        <div className='icon-box' >
-            <div className={`icon-button ${clicked == 0 ? "selected" : ""}`} onClick={() => onClickIcon(0)}>
-                <div className='brushbox-texture' >
-                    default
-                </div>
-            </div>
-            <div id='2' className={`icon-button ${clicked == 1 ? "selected" : ""} water`} onClick={() => onClickIcon(1)}>
-                <div className='brushbox-texture water' >
-                    water
-                </div>
-            </div>
-            <div className={`icon-button ${clicked == 2 ? "selected" : ""} mountain`} onClick={() => onClickIcon(2)}>
-                <div className='brushbox-texture mountain' >
-                    mountain
-                </div>
-            </div>
+  return (
+    <div className='icon-box' >
+      <div
+        className={`icon-button ${brushSelection.terrain === Terrain.NORMAL ? "selected" : ""}`}
+        onClick={()=> onClickIcon(Terrain.NORMAL)}
+      >
+        <div className='brushbox-texture' >
+          default
         </div>
-    )
+      </div>
+      <div 
+        className={`icon-button ${brushSelection.terrain === Terrain.WATER ? "selected" : ""} water`} 
+        onClick={()=> onClickIcon(Terrain.WATER)}
+      >
+        <div className='brushbox-texture water' >
+          water
+        </div>
+      </div>
+      <div
+        className={`icon-button ${brushSelection.terrain === Terrain.ROCK ? "selected" : ""} rock`}
+        onClick={() => onClickIcon(Terrain.ROCK)}>
+        <div className='brushbox-texture rock' >
+          mountain
+        </div>
+      </div>
+    </div>
+  )
 }
 
 export default BrushBoxTextures

--- a/src/components/Brushbox-textures.tsx
+++ b/src/components/Brushbox-textures.tsx
@@ -2,6 +2,8 @@ import { useState } from "react";
 import './Brushbox-textures.css';
 import { Terrain } from "../Model/terrain";
 import { BrushSelection } from "../context";
+import classNames from "classnames";
+
 
 interface BrushBoxProps {
   setBrushSelection: (selection: BrushSelection) => void;
@@ -15,26 +17,35 @@ const BrushBoxTextures = (props: BrushBoxProps) => {
     setBrushSelection({ terrain });
   }
 
+  function btnClass(terrain: Terrain) {
+    return classNames({
+      "icon-button": true,
+      "selected": brushSelection.terrain === terrain,
+      "water": terrain === Terrain.WATER,
+      "rock": terrain === Terrain.ROCK,
+    })
+  }
+
   return (
     <div className='icon-box' >
       <div
-        className={`icon-button ${brushSelection.terrain === Terrain.NORMAL ? "selected" : ""}`}
-        onClick={()=> onClickIcon(Terrain.NORMAL)}
+        className={btnClass(Terrain.NORMAL)}
+        onClick={() => onClickIcon(Terrain.NORMAL)}
       >
         <div className='brushbox-texture' >
           default
         </div>
       </div>
-      <div 
-        className={`icon-button ${brushSelection.terrain === Terrain.WATER ? "selected" : ""} water`} 
-        onClick={()=> onClickIcon(Terrain.WATER)}
+      <div
+        className={btnClass(Terrain.WATER)}
+        onClick={() => onClickIcon(Terrain.WATER)}
       >
         <div className='brushbox-texture water' >
           water
         </div>
       </div>
       <div
-        className={`icon-button ${brushSelection.terrain === Terrain.ROCK ? "selected" : ""} rock`}
+        className={btnClass(Terrain.ROCK)}
         onClick={() => onClickIcon(Terrain.ROCK)}>
         <div className='brushbox-texture rock' >
           mountain

--- a/src/components/Brushbox-textures.tsx
+++ b/src/components/Brushbox-textures.tsx
@@ -1,19 +1,14 @@
 import { useState } from "react";
 import './Brushbox-textures.css';
 import { Terrain } from "../Model/terrain";
+import { BrushSelection } from "../context";
 
-const BrushBoxTextures = ({ brushSelection, setBrushSelection }) => {
+const BrushBoxTextures = ({setBrushSelection} ) => {
     const [clicked, setClicked] = useState(-1)
     const [key, setKey] = useState(0)
 
     const onClickIcon = (terrain: Terrain) => { 
-        let newBrush = brushSelection
-        if (newBrush.hasOwnProperty("terrain")) {
-            newBrush.terrain = JSON.parse(JSON.stringify(terrain))
-        } else {
-            Object.defineProperty(newBrush, "terrain", { value: JSON.parse(JSON.stringify(terrain)), writable: true })
-        }
-        setBrushSelection(newBrush)
+        setBrushSelection({terrain} as BrushSelection)
         setClicked(terrain)
     }
 

--- a/src/components/Brushbox-textures.tsx
+++ b/src/components/Brushbox-textures.tsx
@@ -3,12 +3,18 @@ import './Brushbox-textures.css';
 import { Terrain } from "../Model/terrain";
 import { BrushSelection } from "../context";
 
-const BrushBoxTextures = ({setBrushSelection} ) => {
+interface BrushBoxProps {
+    setBrushSelection: (selection: BrushSelection) => void;
+}
+
+
+const BrushBoxTextures = (props: BrushBoxProps) => {
+    const {setBrushSelection} = props
     const [clicked, setClicked] = useState(-1)
     const [key, setKey] = useState(0)
 
-    const onClickIcon = (terrain: Terrain) => { 
-        setBrushSelection({terrain} as BrushSelection)
+    const onClickIcon = (terrain: Terrain) => {
+        setBrushSelection({ terrain });
         setClicked(terrain)
     }
 

--- a/src/components/Brushbox-textures.tsx
+++ b/src/components/Brushbox-textures.tsx
@@ -2,13 +2,19 @@ import { useState } from "react";
 import './Brushbox-textures.css';
 import { Terrain } from "../Model/terrain";
 
-const BrushBoxTextures = ({ setBrushSelection }) => {
+const BrushBoxTextures = ({ brushSelection, setBrushSelection }) => {
     const [clicked, setClicked] = useState(-1)
     const [key, setKey] = useState(0)
 
-    const onClickIcon = (terrain: Terrain) => {
+    const onClickIcon = (terrain: Terrain) => { 
+        let newBrush = brushSelection
+        if (newBrush.hasOwnProperty("terrain")) {
+            newBrush.terrain = JSON.parse(JSON.stringify(terrain))
+        } else {
+            Object.defineProperty(newBrush, "terrain", { value: JSON.parse(JSON.stringify(terrain)), writable: true })
+        }
+        setBrushSelection(newBrush)
         setClicked(terrain)
-        setBrushSelection({ terrain: terrain })
     }
 
     const selected = clicked == key ? "selected" : "";

--- a/src/components/Brushbox.css
+++ b/src/components/Brushbox.css
@@ -32,3 +32,7 @@
   .selected {
     border: 3px solid blue;
   }
+  
+  .delete {
+    background-color: darksalmon;
+  }

--- a/src/components/Brushbox.tsx
+++ b/src/components/Brushbox.tsx
@@ -1,21 +1,16 @@
 import { useState } from "react"
 import './Brushbox.css';
 import { Icon, IconMap } from '../Model/icon';
+import { BrushSelection } from "../context";
 
 
-const BrushBox = ({brushSelection, setBrushSelection}) => {
+const BrushBox = ({setBrushSelection}) => {
   const IconList: any[] = [];
   const [clicked, setClicked] = useState(-1)
 
   function onClickIcon(icon: Icon) {
     setClicked(icon);
-    let newBrush = brushSelection
-    if (newBrush.hasOwnProperty("icon")) {
-      newBrush.icon = JSON.parse(JSON.stringify( icon )) as Icon 
-    } else {
-      Object.defineProperty(newBrush, "icon", { value:  JSON.parse(JSON.stringify(icon)) , writable: true })
-    }
-    setBrushSelection(newBrush);
+    setBrushSelection({icon} as BrushSelection);
   }
 
   IconMap.forEach((value, key) => {

--- a/src/components/Brushbox.tsx
+++ b/src/components/Brushbox.tsx
@@ -16,7 +16,7 @@ const BrushBox = (props: BrushBoxProps) => {
   function onClickIcon(icon: Icon) {
     setBrushSelection({
       value: brushSelection.value,
-      icon
+      icon,
     });
   }
   
@@ -64,7 +64,10 @@ const BrushBox = (props: BrushBoxProps) => {
       {iconList}
       Icon: {brushSelection.icon}
       value: {brushSelection.value}
-      <button className={`icon-button ${selectDelete}`} onClick={onClickDelete}>
+      <button
+        className={`icon-button ${selectDelete}`}
+        onClick={onClickDelete}
+      >
           Delete
       </button>
       <label>

--- a/src/components/Brushbox.tsx
+++ b/src/components/Brushbox.tsx
@@ -14,7 +14,10 @@ const BrushBox = (props: BrushBoxProps) => {
   const iconList: JSX.Element[] = [];
 
   function onClickIcon(icon: Icon) {
-    setBrushSelection({icon});
+    setBrushSelection({
+      value: brushSelection.value,
+      icon
+    });
   }
   
   function onClickDelete() {
@@ -22,11 +25,9 @@ const BrushBox = (props: BrushBoxProps) => {
   }
 
   const handleInputChange = (event) => {
-    // Remove non-numeric characters using a regular expression
-    const numericValue = event.target.value.replace(/[^0-9]/g, '');
     setBrushSelection({
       ...brushSelection,
-      value: Number(numericValue),
+      value: Number(event.target.value),
     })
   };
 
@@ -63,11 +64,14 @@ const BrushBox = (props: BrushBoxProps) => {
       {iconList}
       Icon: {brushSelection.icon}
       value: {brushSelection.value}
-      <button className={`icon-button ${selectDelete}`} onClick={onClickDelete}>Delete</button>
+      <button className={`icon-button ${selectDelete}`} onClick={onClickDelete}>
+          Delete
+      </button>
       <label>
         <input
+          type="number"
           name="value"
-          onChange={handleInputChange}
+          onInput={handleInputChange}
           placeholder="Enter a value"
         />
       </label>

--- a/src/components/Brushbox.tsx
+++ b/src/components/Brushbox.tsx
@@ -1,28 +1,34 @@
 import { useState } from "react"
 import './Brushbox.css';
 import { Icon, IconMap } from '../Model/icon';
-import { BrushSelection } from "../context";
+import { BrushSelection, BrushSelectionContext } from "../context";
 
 interface BrushBoxProps {
   setBrushSelection: (selection: BrushSelection) => void;
+  brushSelection: BrushSelection;
 }
 
 
 const BrushBox = (props: BrushBoxProps) => {
-  const {setBrushSelection} = props
+  const {setBrushSelection, brushSelection} = props
   const iconList: JSX.Element[] = [];
-  const [clicked, setClicked] = useState(-2)
-  const [value, setValue] = useState("0")
 
   function onClickIcon(icon: Icon) {
-    setClicked(icon);
     setBrushSelection({icon});
   }
   
   function onClickDelete() {
-    setClicked(-1)
     setBrushSelection({deleteIcon: true})
   }
+
+  const handleInputChange = (event) => {
+    // Remove non-numeric characters using a regular expression
+    const numericValue = event.target.value.replace(/[^0-9]/g, '');
+    setBrushSelection({
+      ...brushSelection,
+      value: Number(numericValue),
+    })
+  };
 
   IconMap.forEach((value, key) => {
     let iconStyle: Record<string, string> = {
@@ -37,9 +43,13 @@ const BrushBox = (props: BrushBoxProps) => {
         borderRadius: '14px',
       };
     }
-    const selected = clicked == key ? "selected" : "";
+    const selected = brushSelection.icon === key ? "selected" : "";
     iconList.push(
-      <div key={key} className={`icon-button ${selected}`} onClick={()  => onClickIcon(key)}>
+      <div
+        key={key}
+        className={`icon-button ${selected}`}
+        onClick={() => onClickIcon(key)}
+      >
         <div style={iconStyle} className="icon-brushbox">
           {child}
         </div>
@@ -47,14 +57,19 @@ const BrushBox = (props: BrushBoxProps) => {
     )
   })
 
-  const selectDelete = clicked === -1 ? "selected delete" : "";
+  const selectDelete = brushSelection.deleteIcon ? "selected delete" : "";
   return (
     <div className='icon-box'>
       {iconList}
-      {clicked}
+      Icon: {brushSelection.icon}
+      value: {brushSelection.value}
       <button className={`icon-button ${selectDelete}`} onClick={onClickDelete}>Delete</button>
       <label>
-        <input name="value" value={value} onChange={e => setValue(e.target.value)}/>
+        <input
+          name="value"
+          onChange={handleInputChange}
+          placeholder="Enter a value"
+        />
       </label>
     </div>
   )

--- a/src/components/Brushbox.tsx
+++ b/src/components/Brushbox.tsx
@@ -3,13 +3,19 @@ import './Brushbox.css';
 import { Icon, IconMap } from '../Model/icon';
 
 
-const BrushBox = ({setBrushSelection}) => {
+const BrushBox = ({brushSelection, setBrushSelection}) => {
   const IconList: any[] = [];
   const [clicked, setClicked] = useState(-1)
 
   function onClickIcon(icon: Icon) {
     setClicked(icon);
-    setBrushSelection({ icon });
+    let newBrush = brushSelection
+    if (newBrush.hasOwnProperty("icon")) {
+      newBrush.icon = JSON.parse(JSON.stringify( icon )) as Icon 
+    } else {
+      Object.defineProperty(newBrush, "icon", { value:  JSON.parse(JSON.stringify(icon)) , writable: true })
+    }
+    setBrushSelection(newBrush);
   }
 
   IconMap.forEach((value, key) => {

--- a/src/components/Brushbox.tsx
+++ b/src/components/Brushbox.tsx
@@ -3,14 +3,25 @@ import './Brushbox.css';
 import { Icon, IconMap } from '../Model/icon';
 import { BrushSelection } from "../context";
 
+interface BrushBoxProps {
+  setBrushSelection: (selection: BrushSelection) => void;
+}
 
-const BrushBox = ({setBrushSelection}) => {
-  const IconList: any[] = [];
-  const [clicked, setClicked] = useState(-1)
+
+const BrushBox = (props: BrushBoxProps) => {
+  const {setBrushSelection} = props
+  const iconList: JSX.Element[] = [];
+  const [clicked, setClicked] = useState(-2)
+  const [value, setValue] = useState("0")
 
   function onClickIcon(icon: Icon) {
     setClicked(icon);
-    setBrushSelection({icon} as BrushSelection);
+    setBrushSelection({icon});
+  }
+  
+  function onClickDelete() {
+    setClicked(-1)
+    setBrushSelection({deleteIcon: true})
   }
 
   IconMap.forEach((value, key) => {
@@ -27,7 +38,7 @@ const BrushBox = ({setBrushSelection}) => {
       };
     }
     const selected = clicked == key ? "selected" : "";
-    IconList.push(
+    iconList.push(
       <div key={key} className={`icon-button ${selected}`} onClick={()  => onClickIcon(key)}>
         <div style={iconStyle} className="icon-brushbox">
           {child}
@@ -36,10 +47,15 @@ const BrushBox = ({setBrushSelection}) => {
     )
   })
 
+  const selectDelete = clicked === -1 ? "selected delete" : "";
   return (
     <div className='icon-box'>
-      {IconList}
+      {iconList}
       {clicked}
+      <button className={`icon-button ${selectDelete}`} onClick={onClickDelete}>Delete</button>
+      <label>
+        <input name="value" value={value} onChange={e => setValue(e.target.value)}/>
+      </label>
     </div>
   )
 }

--- a/src/components/HexagonGrid.tsx
+++ b/src/components/HexagonGrid.tsx
@@ -119,7 +119,7 @@ function HexagonGrid(props: HexagonGridProps) {
     setKey(key+1)
   }
 
-  return (<svg width="1000" height="650">
+  return (<svg width="1000" height="650" key={key}>
     {times(hexInfo.rows, (row) => {
       const columns = hexInfo.columns;
       const rowDim = getRowDimensions(row);
@@ -153,7 +153,6 @@ function HexagonGrid(props: HexagonGridProps) {
                 <Hexagon style={getHexStyle(hexagon)} flatTop onClick={() => testOnClick(hexagon)}>
                   <foreignObject width={200} height={200} x="29%" y="30%" style={{ pointerEvents: 'none' }}>
                     {bonus}
-                    <div key={key}></div>
                   </foreignObject>
                 </Hexagon>
               </svg>

--- a/src/components/HexagonGrid.tsx
+++ b/src/components/HexagonGrid.tsx
@@ -92,8 +92,8 @@ function HexagonGrid(props: HexagonGridProps) {
     if (!hex) {
       const newHexagon: HexData = {
         index: hexagon.index,
-        terrain: brushSelection.terrain ? brushSelection.terrain : Terrain.NORMAL,
-        bonus: brushSelection.icon ? {icon: brushSelection.icon} : undefined,
+        terrain: brushSelection.terrain || Terrain.NORMAL,
+        bonus: brushSelection.icon ? {icon: brushSelection.icon, value: brushSelection.value} : undefined,
       }
       hexagons.push(newHexagon)
     } else {
@@ -104,7 +104,8 @@ function HexagonGrid(props: HexagonGridProps) {
       if (brushSelection.icon !== undefined) {
         hex.bonus = {
           ...hex.bonus,
-          icon: brushSelection.icon
+          icon: brushSelection.icon,
+          value: brushSelection.value
         }
       }
 

--- a/src/components/HexagonGrid.tsx
+++ b/src/components/HexagonGrid.tsx
@@ -6,19 +6,19 @@ import { Terrain, TerrainMap } from "../Model/terrain";
 import { HexData } from "../Model/hex";
 import Bonus from "./Bonus";
 import { BrushSelection, BrushSelectionContext } from "../context";
-import { Icon } from "../Model/icon";
+import { Icon, VALUE_ICONS } from "../Model/icon";
 
 function getGridDimensions(
   hexSize = 60,
   columns = 5,
-  rows = 13
+  rows = 13,
 ) {
   return {
     hexSize,
     hexWidth: hexSize * 2,
     hexHeight: Math.ceil(hexSize * Math.sqrt(3)),
     columns,
-    rows
+    rows,
   };
 };
 
@@ -27,7 +27,7 @@ function getHexStyle(hexagon: HexData) {
     fill: TerrainMap.get(hexagon.terrain || Terrain.NORMAL),
     stroke: "black",
     strokeWidth: 2,
-    margin: 0
+    margin: 0,
   };
 }
 
@@ -39,7 +39,7 @@ interface HexagonGridProps {
 function HexagonGrid(props: HexagonGridProps) {
   const {
     hexagons,
-    setHexagons
+    setHexagons,
   } = props;
   const gridWidth = 1000; // TODO: get rid of this
   const brushSelection: BrushSelection = useContext(BrushSelectionContext);
@@ -60,7 +60,7 @@ function HexagonGrid(props: HexagonGridProps) {
     const dimensions = {
       width: `${hexInfo.hexWidth}px`,
       height: `${hexInfo.hexHeight}px`,
-      x: col * hexInfo.hexSize * 3
+      x: col * hexInfo.hexSize * 3,
     };
     if (row % 2 === 1) {
       dimensions.x += hexInfo.hexSize * (3 / 2);
@@ -73,14 +73,14 @@ function HexagonGrid(props: HexagonGridProps) {
       y: `${row * (hexInfo.hexSize * (Math.sqrt(3) / 2))}px`,
       height: `${hexInfo.hexHeight}px`,
       marginLeft: `${(hexInfo.hexSize) * 3}px`,
-      marginTop: 0
+      marginTop: 0,
     };
     if (row % 2 === 0) {
       dimensions = {
         y: `${row * (hexInfo.hexSize * (Math.sqrt(3) / 2))}px`,
         height: `${hexInfo.hexHeight}px`,
         marginLeft: `${(hexInfo.hexSize / 2) * 3}px`,
-        marginTop: 0
+        marginTop: 0,
       };
     }
     return dimensions;
@@ -92,7 +92,7 @@ function HexagonGrid(props: HexagonGridProps) {
     if (!hex) {
       const newHexagon: HexData = {
         index: hexagon.index,
-        terrain: brushSelection.terrain || Terrain.NORMAL,
+        terrain: brushSelection.terrain,
         bonus: brushSelection.icon ? {icon: brushSelection.icon, value: brushSelection.value} : undefined,
       }
       hexagons.push(newHexagon)
@@ -105,12 +105,12 @@ function HexagonGrid(props: HexagonGridProps) {
         hex.bonus = {
           ...hex.bonus,
           icon: brushSelection.icon,
-          value: brushSelection.value
+          value: VALUE_ICONS.includes(brushSelection.icon) ? brushSelection.value : undefined,
         }
       }
 
       if (brushSelection.deleteIcon) {
-        hex.bonus = undefined
+        hex.bonus = undefined;
       }
     }
     

--- a/src/components/HexagonGrid.tsx
+++ b/src/components/HexagonGrid.tsx
@@ -86,27 +86,33 @@ function HexagonGrid(props: HexagonGridProps) {
     return dimensions;
   };
 
-  function testOnClick(hexagon: HexData) {
-    console.log("clicked! now", hexagon,"theme", brushSelection);
-    const newHexagon = hexagons.find(hex => hex.index === hexagon.index) || { index: hexagon.index } as HexData
-    if (brushSelection.icon !== undefined) {
-      newHexagon.bonus = {
-        ...newHexagon.bonus,
-        icon: brushSelection.icon
+  function updateHexagon(hexagon: HexData) {
+    const hex = hexagons.find(hex => hex.index === hexagon.index)
+
+    if (!hex) {
+      const newHexagon: HexData = {
+        index: hexagon.index,
+        terrain: brushSelection.terrain ? brushSelection.terrain : Terrain.NORMAL,
+        bonus: brushSelection.icon ? {icon: brushSelection.icon} : undefined,
+      }
+      hexagons.push(newHexagon)
+    } else {
+      hex.terrain = brushSelection.terrain !== undefined
+        ? brushSelection.terrain 
+        : hex.terrain
+      
+      if (brushSelection.icon !== undefined) {
+        hex.bonus = {
+          ...hex.bonus,
+          icon: brushSelection.icon
+        }
+      }
+
+      if (brushSelection.deleteIcon) {
+        hex.bonus = undefined
       }
     }
-    if (brushSelection.terrain !== undefined) {
-      newHexagon.terrain = brushSelection.terrain;
-    }
-    const foundIndex = hexagons.findIndex(hex => hex.index === hexagon.index);
-    if (foundIndex >= 0) {
-      hexagons[foundIndex] = {
-        ...hexagons[foundIndex],
-        ...newHexagon
-      };
-    } else {
-      hexagons.push(newHexagon);
-    }
+    
     setHexagons([...hexagons]);
   }
 
@@ -140,7 +146,7 @@ function HexagonGrid(props: HexagonGridProps) {
                 width={hexDim.width}
                 x={`${hexDim.x}px`}
               >
-                <Hexagon style={getHexStyle(hexagon)} flatTop onClick={() => testOnClick(hexagon)}>
+                <Hexagon style={getHexStyle(hexagon)} flatTop onClick={() => updateHexagon(hexagon)}>
                   <foreignObject width={200} height={200} x="29%" y="30%" style={{ pointerEvents: 'none' }}>
                     {bonus}
                   </foreignObject>

--- a/src/context.ts
+++ b/src/context.ts
@@ -7,4 +7,4 @@ export interface BrushSelection {
   terrain?: Terrain
 }
 
-export const BrushSelectionContext = createContext({});
+export const BrushSelectionContext = createContext({} as BrushSelection);

--- a/src/context.ts
+++ b/src/context.ts
@@ -9,4 +9,4 @@ export interface BrushSelection {
   deleteIcon?: boolean
 }
 
-export const BrushSelectionContext = createContext({} as BrushSelection);
+export const BrushSelectionContext = createContext<BrushSelection>({});

--- a/src/context.ts
+++ b/src/context.ts
@@ -5,6 +5,8 @@ import { Icon } from './Model/icon';
 export interface BrushSelection {
   icon?: Icon;
   terrain?: Terrain
+  value?: number
+  deleteIcon?: boolean
 }
 
 export const BrushSelectionContext = createContext({} as BrushSelection);


### PR DESCRIPTION
Re-render forced by a change in a key in an temporary element within HexagonGrid.tsx.
Currently there's no empty/default bonus, need to add an unselect option.