### PR TITLE
Make copyable URL to load maps

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,18 +7,12 @@ import BrushBox from './components/Brushbox';
 import BrushBoxTextures from './components/Brushbox-textures';
 import ExportUrl from './components/ExportUrl';
 import HexagonGrid from './components/HexagonGrid';
-import { Icon } from './Model/icon';
-import { Terrain } from './Model/terrain';
 import { useSearchParams } from 'react-router-dom';
 import { useState } from 'react';
 
 function getHexagonsOrDefault(serializedHexes: string | null): HexData[] {
   if (!serializedHexes) {
-    return [{ index: 3, terrain: Terrain.ROCK }, {
-      index: 24, terrain: Terrain.WATER, bonus: {
-        icon: Icon.Clever
-      }
-    }];
+    return [];
   }
   return serializedHexes.split(',').map(decode);
 }

--- a/src/components/ExportUrl.css
+++ b/src/components/ExportUrl.css
@@ -1,0 +1,9 @@
+.share {
+  display: flex;
+  justify-content: center;
+  gap: 10px;
+}
+
+.share input {
+  width: 50%;
+}

--- a/src/components/ExportUrl.tsx
+++ b/src/components/ExportUrl.tsx
@@ -1,14 +1,46 @@
+import './ExportUrl.css';
+
 import { HexData, stringify } from '../Model/hex';
+
+import { Terrain } from '../Model/terrain';
+import { useState } from 'react';
 
 interface ExportUrlProps {
   hexagons: HexData[],
 };
 
+function isDefaultHex(hex: HexData) {
+  const { terrain, upgradeRequired, bonus } = hex;
+  return (terrain === Terrain.NORMAL || !terrain) && !upgradeRequired && !bonus;
+}
+
 function ExportUrl(props: ExportUrlProps) {
   const { hexagons } = props;
-  const hexes = hexagons.map(stringify).join(',');
+  const [showHint, setShowHint] = useState(false);
+  let url = window.location.href.replace(/\?.*/, "");
+  const hexes = hexagons
+    .filter(hex => !isDefaultHex(hex))
+    .map(stringify)
+    .join(',');
+  const newUrl = `${url}?hexes=${hexes}`;
 
-  return <textarea>{hexes}</textarea>
+  function copyToClipboard() {
+    navigator.clipboard.writeText(newUrl);
+    setShowHint(true);
+    setTimeout(() => setShowHint(false), 1500);
+  }
+
+  const hint = showHint ?
+    <div className="hint">Copied to clipboard!</div> :
+    <></>;
+
+  return <div>
+    <div className="share">
+      Share this map!
+      <input value={newUrl} onClick={copyToClipboard}></input>
+    </div>
+    {hint}
+  </div>;
 }
 
 export default ExportUrl;


### PR DESCRIPTION
Implements a way to "save" the map by exporting as a URL, which will open to it.

Filters the hexagons and eliminates empty cells.

Shows a quick message to show that the content has been copied when the input is clicked.